### PR TITLE
Add a new check to make sure bamboo installed properly

### DIFF
--- a/roles/mesos-master/tasks/dependencies.yml
+++ b/roles/mesos-master/tasks/dependencies.yml
@@ -72,11 +72,17 @@
     - golang
     - haproxy
 
+- name: check if bamboo deb exists
+  stat:
+    path: /tmp/bamboo/output/bamboo_1.0.0-1_all.deb
+  register: bamboo_folder
+
 - name: check if the required version of bamboo is already installed
   command: 'git describe --tags'
   args:
     chdir: '/tmp/bamboo'
   register: bamboo_current_version
+  when: bamboo_folder.stat.islnk is defined
   changed_when: False
   tags:
     - bamboo
@@ -84,7 +90,7 @@
 - name: Install fpm using ruby gems
   tags: bamboo
   command: gem install fpm
-  when: bamboo_current_version.stdout.find('{{ bamboo_release }}') == -1
+  when: bamboo_folder.stat.islnk is not defined or bamboo_current_version.stdout.find('{{ bamboo_release }}') == -1
 
 - name: Fetch bamboo version {{ bamboo_release }} release from github
   tags: bamboo
@@ -92,7 +98,7 @@
     repo: https://github.com/QubitProducts/bamboo.git
     dest: /tmp/bamboo
     version: "{{ bamboo_release }}"
-  when: bamboo_current_version.stdout.find('{{ bamboo_release }}') == -1
+  when: bamboo_folder.stat.islnk is not defined or bamboo_current_version.stdout.find('{{ bamboo_release }}') == -1
 
 - name: Get bamboo dependencies
   tags: bamboo
@@ -101,7 +107,7 @@
   shell: go get -d
   args:
     chdir: /tmp/bamboo
-  when: bamboo_current_version.stdout.find('{{ bamboo_release }}') == -1
+  when: bamboo_folder.stat.islnk is not defined or bamboo_current_version.stdout.find('{{ bamboo_release }}') == -1
 
 - name: Build bamboo from source
   tags: bamboo
@@ -110,17 +116,17 @@
   shell: go build bamboo.go
   args:
     chdir: /tmp/bamboo
-  when: bamboo_current_version.stdout.find('{{ bamboo_release }}') == -1
+  when: bamboo_folder.stat.islnk is not defined or bamboo_current_version.stdout.find('{{ bamboo_release }}') == -1
 
 - name: Build bamboo .deb package
   tags: bamboo
   shell: ./builder/build.sh
   args:
     chdir: /tmp/bamboo
-  when: bamboo_current_version.stdout.find('{{ bamboo_release }}') == -1
+  when: bamboo_folder.stat.islnk is not defined or bamboo_current_version.stdout.find('{{ bamboo_release }}') == -1
 
 - name: Install bamboo .deb
   tags: bamboo
   apt:
     deb: "/tmp/bamboo/output/bamboo_1.0.0-1_all.deb"
-  when: bamboo_current_version.stdout.find('{{ bamboo_release }}') == -1
+  when: bamboo_folder.stat.islnk is not defined or bamboo_current_version.stdout.find('{{ bamboo_release }}') == -1


### PR DESCRIPTION
If bamboo is not already installed the "check if the required version of bamboo is already installed" task will fail. This fixes by checking if the deb exists.
