### PR TITLE
Add GlusterFS support to jenkins

### DIFF
--- a/inventory/ec2.ini
+++ b/inventory/ec2.ini
@@ -11,7 +11,7 @@
 # AWS regions to make calls to. Set this to 'all' to make request to all regions
 # in AWS and merge the results together. Alternatively, set this to a comma
 # separated list of regions. E.g. 'us-east-1,us-west-1,us-west-2'
-regions = all
+regions = us-east-1
 regions_exclude = us-gov-west-1,cn-north-1
 
 # When generating inventory, Ansible needs to know how to address a server.

--- a/roles/jenkins/handlers/main.yml
+++ b/roles/jenkins/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: restart consul
+  service:
+    name: consul
+    enabled: yes
+    state: restarted

--- a/roles/jenkins/tasks/main.yml
+++ b/roles/jenkins/tasks/main.yml
@@ -121,5 +121,5 @@
   notify:
     - restart consul
   tags:
-    - jenkinsconsul
+    - jenkins
     - consul

--- a/roles/jenkins/tasks/main.yml
+++ b/roles/jenkins/tasks/main.yml
@@ -1,4 +1,37 @@
 ---
+- name: Install GlusterFS PPA
+  apt_repository:
+    repo: "ppa:gluster/glusterfs-3.7"
+  tags:
+    - gluster
+    - jenkins
+
+- name: Install GlusterFS client
+  apt:
+    name: "glusterfs-client"
+    state: present
+  tags:
+    - gluster
+    - jenkins
+
+- name: Ensure gluster volume mountpoint exists
+  file:
+    path: "{{ jenkins_gluster_mountpoint }}"
+    state: directory
+  tags:
+    - gluster
+    - jenkins
+
+- name: Mount gluster volume for jenkins persistent storage
+  mount:
+    name: "{{ jenkins_gluster_mountpoint }}"
+    src: "{{ groups.storage[0] }}:/{{ jenkins_gluster_volume }}"
+    fstype: glusterfs
+    state: mounted
+  tags:
+    - gluster
+    - jenkins
+
 - name: Add docker deb repository keys
   apt_key:
     keyserver: p80.pool.sks-keyservers.net
@@ -67,6 +100,7 @@
     name: jenkins
     image: partinfra/jenkins
     state: started
+    pull: always
     ports:
       - "80:8080"
       - "5000:5000"
@@ -75,6 +109,7 @@
     restart_policy: always
   tags:
     - jenkins
+    - startjenkins
 
 - name: Setup consul service and check definitions
   template:
@@ -86,5 +121,5 @@
   notify:
     - restart consul
   tags:
-    - jenkins
+    - jenkinsconsul
     - consul

--- a/site.yml
+++ b/site.yml
@@ -36,6 +36,7 @@
   vars:
     gluster_volumes:
       - marathon
+      - jenkins
 
 - hosts: mesos-master
   sudo: yes
@@ -64,3 +65,6 @@
     - jenkins
   tags:
     - jenkins
+  vars:
+    jenkins_gluster_volume: 'jenkins'
+    jenkins_gluster_mountpoint: '/opt/jenkins'


### PR DESCRIPTION
- Use GlusterFS volume to store Jenkins data
- Ensure image is always pulled on restart
- Set Ansible to only search in the us-east-1 region
