### PR TITLE
Ensure Jenkins is reloaded when config changes

### DIFF
--- a/roles/jenkins/tasks/main.yml
+++ b/roles/jenkins/tasks/main.yml
@@ -99,7 +99,7 @@
   docker:
     name: jenkins
     image: partinfra/jenkins
-    state: started
+    state: reloaded
     pull: always
     ports:
       - "80:8080"


### PR DESCRIPTION
`started` only makes sure the container is started whereas `reloaded` launches a new container when any of the ansible options have changed.
