### PR TITLE
Pull tagged releases for Jenkins

### DIFF
--- a/roles/jenkins/tasks/main.yml
+++ b/roles/jenkins/tasks/main.yml
@@ -98,7 +98,7 @@
 - name: Run jenkins docker
   docker:
     name: jenkins
-    image: partinfra/jenkins
+    image: partinfra/jenkins:{{ jenkins_release }}
     state: reloaded
     pull: always
     ports:

--- a/roles/jenkins/vars/main.yml
+++ b/roles/jenkins/vars/main.yml
@@ -1,0 +1,3 @@
+---
+
+jenkins_release: "2016.7-2"


### PR DESCRIPTION
- Add `jenkins_release` var
- Pull release 2016.7-2
