### PR TITLE
Add EFS Mount for persistent storage

### DIFF
--- a/group_vars/mesos-slave
+++ b/group_vars/mesos-slave
@@ -24,3 +24,8 @@ marathon_app_volumes:
   - "wordpress-ops-staging"
   - "wordpress-mozillaireland-production"
   - "wordpress-mozillaireland-staging"
+marathon_gluster_volume: 'marathon'
+marathon_gluster_mountpoint: '/srv/marathon'
+marathon_efs_mountpoint: '/srv/marathon-efs'
+marathon_staging_filesystem_id: 'fs-669b552f'
+marathon_production_filesystem_id: 'fs-799b5530'

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+  - name: Get extra EC2 facts
+    action: ec2_facts
+    tags:
+      - storage
+      - efs
+
   - name: install ssh keys
     authorized_key:
       user: "{{ item.user }}"

--- a/roles/mesos-slave/tasks/dependencies.yml
+++ b/roles/mesos-slave/tasks/dependencies.yml
@@ -4,6 +4,7 @@
   apt_repository:
     repo: "ppa:gluster/glusterfs-3.7"
   tags:
+    - storage
     - gluster
 
 - name: Install GlusterFS client
@@ -11,7 +12,16 @@
     name: "glusterfs-client"
     state: present
   tags:
+    - storage
     - gluster
+
+- name: Install NFS client
+  apt:
+    name: "nfs-common"
+    state: present
+  tags:
+    - storage
+    - efs
 
 - name: Add docker deb repository keys
   apt_key:

--- a/roles/mesos-slave/tasks/mounts.yml
+++ b/roles/mesos-slave/tasks/mounts.yml
@@ -5,6 +5,7 @@
     path: "{{ marathon_gluster_mountpoint }}"
     state: directory
   tags:
+    - storage
     - gluster
 
 - name: Mount gluster volume for marathon apps persistent storage
@@ -14,7 +15,42 @@
     fstype: glusterfs
     state: mounted
   tags:
+    - storage
     - gluster
+
+- name: Ensure EFS mountpoint exists
+  file:
+    path: "{{ marathon_efs_mountpoint }}"
+    state: directory
+  tags:
+    - storage
+    - efs
+
+- name: Set EFS Filesystem ID for staging
+  set_fact:
+    marathon_filesystem_id: "{{ marathon_staging_filesystem_id }}"
+  when: ec2_tag_env == "staging"
+  tags:
+    - storage
+    - efs
+
+- name: Set EFS Filesystem ID for production
+  set_fact:
+    marathon_filesystem_id: "{{ marathon_production_filesystem_id }}"
+  when: ec2_tag_env == "production"
+  tags:
+    - storage
+    - efs
+
+- name: Mount EFS target for persistent app storage
+  mount:
+    name: "{{ marathon_efs_mountpoint }}"
+    src: "{{ ansible_ec2_placement_availability_zone }}.{{ marathon_filesystem_id }}.efs.{{ ec2_region }}.amazonaws.com:/"
+    fstype: nfs4
+    state: mounted
+  tags:
+    - storage
+    - efs
 
 - name: Create directories for marathon volumes
   file:
@@ -22,4 +58,14 @@
     state: directory
   with_items: "{{ marathon_app_volumes }}"
   tags:
+    - storage
     - gluster
+
+- name: Create directories for marathon-efs volumes
+  file:
+    path: "{{ marathon_efs_mountpoint }}/{{ item }}"
+    state: directory
+  with_items: "{{ marathon_app_volumes }}"
+  tags:
+    - storage
+    - efs

--- a/site.yml
+++ b/site.yml
@@ -52,9 +52,6 @@
   roles:
     - mesos-common
     - mesos-slave
-  vars:
-    marathon_gluster_volume: 'marathon'
-    marathon_gluster_mountpoint: '/srv/marathon'
   tags:
     - mesos-slave
 


### PR DESCRIPTION
- Gather extra facts from the ec2_facts module
- Add 'storage' tag to both EFS and Gluster tasks
- Add variables for staging/production EFS FS IDs
