### PR TITLE
Add logstash filter to parse graphite formatted results.

### DIFF
--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -55,26 +55,18 @@
   tags:
     - logstash
 
-- name: Add logstash UDP input
+- name: Add logstash input/filter/output configuration
   template:
-    src: 00-udp-input.conf.j2
-    dest: /etc/logstash/conf.d/00-udp-input.conf
+    src: "{{ item }}"
+    dest: "/etc/logstash/conf.d/{{ item|replace('conf.j2', 'conf')"
     owner: root
     group: root
     mode: 0644
-  tags:
-    - logstash
+  with_items:
+    - 00-udp-input.conf.j2
+    - 10-elasticsearch-output.conf.j2
+    - 20-sensu-metrics-filter.conf.j2
   notify:
     - restart logstash
-
-- name: Add logstash ES output
-  template:
-    src: 10-elasticsearch-output.conf.j2
-    dest: /etc/logstash/conf.d/10-elasticsearch-output.conf
-    owner: root
-    group: root
-    mode: 0644
   tags:
     - logstash
-  notify:
-    - restart logstash

--- a/roles/logstash/templates/20-sensu-metrics-filter.conf.j2
+++ b/roles/logstash/templates/20-sensu-metrics-filter.conf.j2
@@ -1,0 +1,30 @@
+filter {
+
+    if [type] == "sensu" and [check][type] == "metric" {
+
+        # Change event timestamp to the sensu check execution timestamp
+        date {
+            match => ["[check][executed]", "UNIX"]
+        }
+
+        # Workaround to the way logstash treats \n
+        mutate {
+            gsub => ["[check][output]", "\n", "LINE_BREAK"]
+        }
+
+        # Split graphite metrics from multiline to array
+        mutate {
+            split => ["[check][output]", "LINE_BREAK"]
+        }
+
+        # Parse graphite metrics
+        grok {
+            match => ["[check][output]", "%{DATA:sensu_metric_name} %{BASE16FLOAT:sensu_metric_value %{INT}"]
+        }
+
+        # Convert metric result to float
+        mutate {
+            convert => ["sensu_metric_value", "float"]
+        }
+    }
+}


### PR DESCRIPTION
* Sensu metrics usually provide graphite formatted results (either single-line, or multi-line)
  * ``<dotted>.<metric>.<name> <value> <timestamp>``
  * ``<dotted>.<metric>.<name> <value> <timestamp>\n<dotted>.<metric>.<name> <value> <timestamp>\n``
* We should filter sensu metrics and parse ``check.output`` to a more usable format (right now its text)