### PR TITLE
Install mesos packages separately, keep them up to date

### DIFF
--- a/roles/mesos-master/tasks/dependencies.yml
+++ b/roles/mesos-master/tasks/dependencies.yml
@@ -41,23 +41,24 @@
   tags:
     - zookeeper
 
-- name: Install zookeeper
+- name: Install zookeeper and mesos
   apt:
     name: "{{ item }}"
-    state: present
+    state: latest
   with_items:
     - zookeeper
     - zookeeperd
-  tags:
-    - zookeeper
-
-- name: Install mesosphere
-  apt:
-    name: mesosphere
-    state: present
+    - mesos
+    - marathon
+    - chronos
+  notify:
+    - restart zookeeper
+    - restart mesos-master
+    - restart marathon
   tags:
     - mesos
     - marathon
+    - zookeeper
 
 - name: Install haproxy
   apt:

--- a/roles/mesos-slave/tasks/dependencies.yml
+++ b/roles/mesos-slave/tasks/dependencies.yml
@@ -76,7 +76,7 @@
 - name: Install mesos
   apt:
     name: mesos
-    state: present
+    state: latest
   tags:
     - mesos
 


### PR DESCRIPTION
We need to keep mesos at a consistent version between all nodes, so we need to ensure the packages from the metapackages are upgraded when ansible runs.