### PR TITLE
Use https instead of http

### DIFF
--- a/roles/mesos-master/files/haproxy.ctmpl
+++ b/roles/mesos-master/files/haproxy.ctmpl
@@ -50,12 +50,12 @@ frontend http-in
         # Permanent redirects
         {{- range ls $redirect_301 }}
         acl redirect-{{ .Key }} hdr(host) -i {{ .Key }}
-        http-request redirect prefix http://{{ .Value }} code 301 if redirect-{{ .Key }}
+        http-request redirect prefix https://{{ .Value }} code 301 if redirect-{{ .Key }}
         {{ end }}
         # Temporary redirects
         {{- range ls $redirect_302 }}
         acl redirect-{{ .Key }} hdr(host) -i {{ .Key }}
-        http-request redirect prefix http://{{ .Value }} code 302 if redirect-{{ .Key }}
+        http-request redirect prefix https://{{ .Value }} code 302 if redirect-{{ .Key }}
         {{ end }}
 
         # Services


### PR DESCRIPTION
Note: this only works when we have all sites affected from this config hosted on https. If this breaks something, let's use https for that as well.