### PR TITLE
Always use latest version of the Jenkins image

### DIFF
--- a/roles/jenkins/vars/main.yml
+++ b/roles/jenkins/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 
-jenkins_release: "2017.07-2"
+jenkins_release: "latest"


### PR DESCRIPTION
The library version of Jenkins has been deprecated, and the Jenkins versions are only tagged by `lts` and `latest`.